### PR TITLE
Avoid collapsing slashes that follow http or https

### DIFF
--- a/test_urlnorm.py
+++ b/test_urlnorm.py
@@ -97,6 +97,9 @@ def pytest_generate_tests(metafunc):
             '/foo/../bar':                   '/bar',
             '/foo//':                        '/foo/',
             '/foo///bar//':                  '/foo/bar/',
+            '/http://foo.com/':              '/http://foo.com/',
+            '/https://foo.com/':             '/https://foo.com/',
+            '/300x200/http://foo.com//':     '/300x200/http://foo.com/',
         }
         for bad, good in tests.items():
             metafunc.addcall(funcargs=dict(bad=bad, good=good))


### PR DESCRIPTION
Code to address #9

I have done very little Python programming so I'm very open to any style feedback.

I am not terribly happy with how the implementation turned out. I tried very hard to do it inside of the `_collapse` regex but negative lookbehind assertions only accept fixed length strings. So I could test http or https but not the expression `https?`.

Summary of the implementation:
I removed "//" from the `_collapse` expression and now extract double slashes in the `collapse_double_slashes` method where I check if it is preceded by http or https before removing the slashes.
