### PR TITLE
Use sets O(1) to avoid repeated O(n) operations during char scans

### DIFF
--- a/urlnorm.py
+++ b/urlnorm.py
@@ -88,24 +88,24 @@ _default_port = {   'http': '80',
                     'telnet': '23',
                     'prospero': '191',
                 }
-_relative_schemes = [   'http',
-                        'https',
-                        'ws',
-                        'wss',
-                        'itms',
-                        'news',
-                        'snews',
-                        'nntp',
-                        'snntp',
-                        'ftp',
-                        'file',
-                        ''
-                    ]
+_relative_schemes = set([   'http',
+                            'https',
+                            'ws',
+                            'wss',
+                            'itms',
+                            'news',
+                            'snews',
+                            'nntp',
+                            'snntp',
+                            'ftp',
+                            'file',
+                            ''
+                            ])
 
-params_unsafe_list = ' ?=+%#;'
-qs_unsafe_list = ' ?&=+%#'
-fragment_unsafe_list = ' +%#'
-path_unsafe_list = ' /?;%+#'
+params_unsafe_list = set(' ?=+%#;')
+qs_unsafe_list = set(' ?&=+%#')
+fragment_unsafe_list = set(' +%#')
+path_unsafe_list = set(' /?;%+#')
 _hextochr = dict(('%02x' % i, chr(i)) for i in range(256))
 _hextochr.update(('%02X' % i, chr(i)) for i in range(256))
 


### PR DESCRIPTION
This amounts to a significant performance boost.