### PR TITLE
unescape space in params, query string, and fragments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 # also update in urlnorm.py
-version = '1.1.3'
+version = '1.1.4'
 
 setup(name='urlnorm',
         version=version,

--- a/test_urlnorm.py
+++ b/test_urlnorm.py
@@ -39,13 +39,13 @@ def pytest_generate_tests(metafunc):
             
             # check that %23 (#) is not escaped where it shouldn't be
             'http://test.example/?p=%23val#test-%23-val%25': 'http://test.example/?p=%23val#test-%23-val%25',
-            # check that %20 or %25 is not unescaped to ' ' or %
-            'http://test.example/%25/?p=%20val%20%25' : 'http://test.example/%25/?p=%20val%20%25',
+            # check that %25 is not unescaped to %
+            'http://test.example/%25/?p=val%25ue' : 'http://test.example/%25/?p=val%25ue',
             "http://test.domain/I%C3%B1t%C3%ABrn%C3%A2ti%C3%B4n%EF%BF%BDliz%C3%A6ti%C3%B8n" : "http://test.domain/I\xc3\xb1t\xc3\xabrn\xc3\xa2ti\xc3\xb4n\xef\xbf\xbdliz\xc3\xa6ti\xc3\xb8n",
-            # check that spaces in paths are not escaped
-            'http://test.example/abcde%20def' : 'http://test.example/abcde def',
+            # check that %20 in paths, params, query strings, and fragments are unescaped
+            'http://test.example/abcde%20def?que%20ry=str%20ing#frag%20ment' : 'http://test.example/abcde def?que ry=str ing#frag ment',
             # check that spaces are collated to '+'
-            "http://test.example/path/with a%20space+/" : "http://test.example/path/with a space+/",  # spaces in apths are ok
+            "http://test.example/path;par%20ams/with a%20space+/" : "http://test.example/path;par ams/with a space+/",  # spaces in paths are ok
             "http://[2001:db8:1f70::999:de8:7648:6e8]/test" : "http://[2001:db8:1f70::999:de8:7648:6e8]/test", #ipv6 address
             "http://[::ffff:192.168.1.1]/test" : "http://[::ffff:192.168.1.1]/test", # ipv4 address in ipv6 notation
             "http://[::ffff:192.168.1.1]:80/test" : "http://[::ffff:192.168.1.1]/test", # ipv4 address in ipv6 notation

--- a/urlnorm.py
+++ b/urlnorm.py
@@ -26,6 +26,7 @@ Available functions:
 
 
 CHANGES:
+1.1.4 - unescape " " in params, query string, and fragments
 1.1.3 - don't escape " " in path
 1.1.2 - leave %20 as %20, collate ' ' to %20, leave '+' as '+'
 1.1 - collate %20 and ' ' to '+'
@@ -64,7 +65,7 @@ SOFTWARE.
 """
 
 # also update in setup.py
-__version__ = "1.1.2"
+__version__ = "1.1.4"
 
 from urlparse import urlparse, urlunparse
 from string import lower
@@ -103,9 +104,9 @@ _relative_schemes = set(['http',
                          ''
                          ])
 
-params_unsafe_list = set(' ?=+%#;')
-qs_unsafe_list = set(' ?&=+%#')
-fragment_unsafe_list = set(' +%#')
+params_unsafe_list = set('?=+%#;')
+qs_unsafe_list = set('?&=+%#')
+fragment_unsafe_list = set('+%#')
 path_unsafe_list = set('/?;%+#')
 _hextochr = dict(('%02x' % i, chr(i)) for i in range(256))
 _hextochr.update(('%02X' % i, chr(i)) for i in range(256))


### PR DESCRIPTION
@jehiah made a few adjustments to the list of unsafe characters that we will not be unescaping.

RFR
